### PR TITLE
Pin openmicroscopy.postgresql to 2.0.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,7 @@
 ---
 
 - src: openmicroscopy.postgresql
+  version: 2.0.0
 
 - name: openmicroscopy.omero-common
   src:  https://github.com/openmicroscopy/ansible-role-omero-common.git


### PR DESCRIPTION
While the PG role undergoes a few milestones for
the new 3.0 version, pin all requirements to the
latest stable, 2.0.0.

See https://github.com/openmicroscopy/ansible-role-postgresql/pull/6